### PR TITLE
Fix how jest-dom/matchers are importer

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,7 +3,7 @@ import { cleanup } from '@testing-library/react'
 import matchers from '@testing-library/jest-dom/matchers'
 
 // extend vite's expect method with matchers from react test lib
-expect.extend(matchers)
+// expect.extend(matchers);
 
 // cleanup after each test case (clearing jsdom etc)
 afterEach(() => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,9 +1,9 @@
 import { expect, afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
-import matchers from '@testing-library/jest-dom/matchers'
+import * as matchers from '@testing-library/jest-dom/matchers'
 
 // extend vite's expect method with matchers from react test lib
-// expect.extend(matchers);
+expect.extend(matchers)
 
 // cleanup after each test case (clearing jsdom etc)
 afterEach(() => {


### PR DESCRIPTION
## Description
While running `npm run test`, I kept getting an error due to the way jest-dom/matchers was imported. The fix was to import it as a namespace. 

