### PR TITLE
Replacing ts-standard with prettier-standard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    timeout-minutes: 12
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [lts/*, 19.x, 18.x, 16.x]
+
+    runs-on: ${{ matrix.os }} 
+        
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build --if-present

--- a/.github/workflows/todo.yml
+++ b/.github/workflows/todo.yml
@@ -1,0 +1,18 @@
+name: "TODO"
+on: ["push"]
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@master"
+      - name: "todo-to-issue"
+        uses: "senecajs/todo-to-issue-action@master"
+        with:
+          REPO: ${{ github.repository }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL: "TODO:"
+          COMMENT_MARKER: "//"
+          INCLUDE_EXT: ".ts,.tsx,.js,.md"
+        id: "todo"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist
+.next
+**/*.md

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "reset": "npm run clean && npm install && npm run build",
     "repo-check": "REPO_VERSION=`node -e \"console.log(require('./package').version)\"` && echo TAG: v$REPO_VERSION && [[ '' == `git tag --list v${REPO_VERSION}` ]]",
     "repo-tag": "REPO_VERSION=`node -e \"console.log(require('./package').version)\"` && echo TAG: v$REPO_VERSION && git commit -a -m v$REPO_VERSION && git push && git tag v$REPO_VERSION && git push --tags;",
-    "repo-publish": "npm run repo-check && npm run clean && npm install --registry https://registry.npmjs.org && npm run build && npm test && npm run repo-tag && npm publish --registry https://registry.npmjs.org",
-    "repo-publish-quick": "npm run repo-check && npm run build && npm run repo-tag && npm publish --registry https://registry.npmjs.org --access=public",
-    "lint": "npx ts-standard 'src/**/*.tsx'",
-    "lint-and-fix": "npx ts-standard --fix 'src/**/*.tsx'"
+    "repo-publish": "npm run repo-check && npm run clean && npm install --registry https://registry.npmjs.org && npm run repo-publish-quick",
+    "repo-publish-quick": "npm run repo-check && npm run lint && npm run build && npm run test && npm run repo-tag && npm publish --registry https://registry.npmjs.org --access=public",
+    "lint": "ts-standard src",
+    "lint-and-fix": "ts-standard --fix src"
   },
   "peerDependencies": {
     "@emotion/react": ">=11",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "reset": "npm run clean && npm install && npm run build",
     "repo-check": "REPO_VERSION=`node -e \"console.log(require('./package').version)\"` && echo TAG: v$REPO_VERSION && [[ '' == `git tag --list v${REPO_VERSION}` ]]",
     "repo-tag": "REPO_VERSION=`node -e \"console.log(require('./package').version)\"` && echo TAG: v$REPO_VERSION && git commit -a -m v$REPO_VERSION && git push && git tag v$REPO_VERSION && git push --tags;",
-    "repo-publish": "npm run repo-check && npm run clean && npm install --registry https://registry.npmjs.org && npm run repo-publish-quick",
-    "repo-publish-quick": "npm run repo-check && npm run lint && npm run build && npm run test && npm run repo-tag && npm publish --registry https://registry.npmjs.org --access=public",
+    "repo-publish": "npm run repo-check && npm run clean && npm install --registry https://registry.npmjs.org && npm run build && npm test && npm run repo-tag && npm publish --registry https://registry.npmjs.org",
+    "repo-publish-quick": "npm run repo-check && npm run build && npm run repo-tag && npm publish --registry https://registry.npmjs.org --access=public",
     "lint": "prettier-standard --lint",
     "format": "prettier-standard --format"
   },

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "repo-tag": "REPO_VERSION=`node -e \"console.log(require('./package').version)\"` && echo TAG: v$REPO_VERSION && git commit -a -m v$REPO_VERSION && git push && git tag v$REPO_VERSION && git push --tags;",
     "repo-publish": "npm run repo-check && npm run clean && npm install --registry https://registry.npmjs.org && npm run repo-publish-quick",
     "repo-publish-quick": "npm run repo-check && npm run lint && npm run build && npm run test && npm run repo-tag && npm publish --registry https://registry.npmjs.org --access=public",
-    "lint": "ts-standard src",
-    "lint-and-fix": "ts-standard --fix src"
+    "lint": "prettier-standard --lint",
+    "format": "prettier-standard --format"
   },
   "peerDependencies": {
     "@emotion/react": ">=11",
@@ -72,6 +72,7 @@
     "gubu": "^5.0.1",
     "jsdom": "^22.1.0",
     "msw": "^1.3.0",
+    "prettier-standard": "^16.4.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-redux": "8.0.5",
@@ -80,7 +81,6 @@
     "redux-mock-store": "^1.5.4",
     "redux-thunk": "^2.4.2",
     "styled-components": "5.3.8",
-    "ts-standard": "^12.0.2",
     "typescript": "5.1.6",
     "vite": "4.4.9",
     "vite-plugin-dts": "3.5.2",


### PR DESCRIPTION
## Description
I'm replacing `ts-standard` with `prettier-standard` because `standardjs vscode plugin` doesn't seem to have good support for `.ts` and `.tsx` files. 

The `prettier-standard` vscode plugin has good support  for typescript, especially `formatOnSave`. 

Also `prettier-standard` lint output is just ... well prettier to look at. 